### PR TITLE
fix: Address 9 silent degradation findings in llm/ module

### DIFF
--- a/src/agent_haymaker/llm/config.py
+++ b/src/agent_haymaker/llm/config.py
@@ -5,9 +5,10 @@ Public API (the "studs"):
 """
 
 import os
+import re
 from typing import Literal
 
-from pydantic import BaseModel, Field, SecretStr, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 
 class LLMConfig(BaseModel):
@@ -34,8 +35,26 @@ class LLMConfig(BaseModel):
     endpoint: str | None = Field(None, description="Azure endpoint URL")
     deployment: str | None = Field(None, description="Azure OpenAI deployment name")
     api_version: str = Field("2024-02-15-preview", description="Azure OpenAI API version")
-    timeout_seconds: int = Field(120, description="Request timeout in seconds")
-    max_retries: int = Field(3, description="Maximum retry attempts")
+    timeout_seconds: int = Field(120, ge=1, le=600, description="Request timeout in seconds")
+    max_retries: int = Field(3, ge=0, le=10, description="Maximum retry attempts")
+
+    @field_validator("api_version")
+    @classmethod
+    def validate_api_version(cls, v: str) -> str:
+        """Validate api_version matches YYYY-MM-DD or YYYY-MM-DD-preview format."""
+        if not re.match(r"^\d{4}-\d{2}-\d{2}(-preview)?$", v):
+            raise ValueError(
+                f"Invalid api_version format: {v!r}. Expected YYYY-MM-DD or YYYY-MM-DD-preview"
+            )
+        return v
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint(cls, v: str | None) -> str | None:
+        """Validate endpoint URL starts with https://."""
+        if v is not None and not v.startswith("https://"):
+            raise ValueError(f"endpoint must start with 'https://': {v!r}")
+        return v
 
     @model_validator(mode="after")
     def validate_provider_config(self) -> "LLMConfig":
@@ -80,27 +99,56 @@ class LLMConfig(BaseModel):
         provider = os.environ.get("LLM_PROVIDER", "anthropic")
 
         if provider == "anthropic":
+            api_key = os.environ.get("ANTHROPIC_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "ANTHROPIC_API_KEY environment variable is required when LLM_PROVIDER=anthropic"
+                )
             return cls(
                 provider="anthropic",
-                api_key=os.environ.get("ANTHROPIC_API_KEY"),
+                api_key=api_key,
             )
 
         elif provider == "azure_openai":
+            endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+            deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+            if not endpoint:
+                raise ValueError(
+                    "AZURE_OPENAI_ENDPOINT environment variable is required "
+                    "when LLM_PROVIDER=azure_openai"
+                )
+            if not deployment:
+                raise ValueError(
+                    "AZURE_OPENAI_DEPLOYMENT environment variable is required "
+                    "when LLM_PROVIDER=azure_openai"
+                )
             api_key = os.environ.get("AZURE_OPENAI_API_KEY")
             return cls(
                 provider="azure_openai",
-                endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
-                deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT"),
+                endpoint=endpoint,
+                deployment=deployment,
                 api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-02-15-preview"),
                 api_key=api_key if api_key else None,
             )
 
         elif provider == "azure_ai_foundry":
+            endpoint = os.environ.get("AZURE_AI_FOUNDRY_ENDPOINT")
+            model = os.environ.get("AZURE_AI_FOUNDRY_MODEL")
+            if not endpoint:
+                raise ValueError(
+                    "AZURE_AI_FOUNDRY_ENDPOINT environment variable is required "
+                    "when LLM_PROVIDER=azure_ai_foundry"
+                )
+            if not model:
+                raise ValueError(
+                    "AZURE_AI_FOUNDRY_MODEL environment variable is required "
+                    "when LLM_PROVIDER=azure_ai_foundry"
+                )
             api_key = os.environ.get("AZURE_AI_FOUNDRY_API_KEY")
             return cls(
                 provider="azure_ai_foundry",
-                endpoint=os.environ.get("AZURE_AI_FOUNDRY_ENDPOINT"),
-                model=os.environ.get("AZURE_AI_FOUNDRY_MODEL"),
+                endpoint=endpoint,
+                model=model,
                 api_key=api_key if api_key else None,
             )
 

--- a/tests/unit/test_llm_config.py
+++ b/tests/unit/test_llm_config.py
@@ -114,9 +114,7 @@ class TestLLMConfig:
 
     def test_from_env_default_provider(self):
         env = {"ANTHROPIC_API_KEY": "sk-default"}
-        with patch.dict(os.environ, env, clear=False):
-            # Remove LLM_PROVIDER if set
-            with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop("LLM_PROVIDER", None)
-                config = LLMConfig.from_env()
-                assert config.provider == "anthropic"
+        with patch.dict(os.environ, env, clear=True):
+            # clear=True removes LLM_PROVIDER entirely, avoiding os.environ.pop leak
+            config = LLMConfig.from_env()
+            assert config.provider == "anthropic"

--- a/tests/unit/test_llm_types.py
+++ b/tests/unit/test_llm_types.py
@@ -18,6 +18,14 @@ class TestLLMMessage:
         msg = LLMMessage(role="system", content="You are helpful")
         assert msg.role == "system"
 
+    def test_message_accepts_any_role(self):
+        """LLMMessage intentionally accepts any role string.
+
+        Validation happens at provider level, not at the message type level.
+        """
+        msg = LLMMessage(role="custom_role", content="test")
+        assert msg.role == "custom_role"
+
 
 class TestLLMResponse:
     def test_create_response(self):


### PR DESCRIPTION
## Summary

- **B-1**: Name missing environment variables in `from_env()` error messages for all three providers (anthropic, azure_openai, azure_ai_foundry) so operators can identify the exact missing variable
- **B-2**: Add `field_validator` for `api_version` format enforcing `YYYY-MM-DD` or `YYYY-MM-DD-preview` pattern
- **B-3**: Add `field_validator` for `endpoint` URL requiring `https://` prefix
- **B-6**: Add bounds on `timeout_seconds` (1-600) and `max_retries` (0-10) via Pydantic `Field` constraints
- **A-1**: Document `ChatCompletionsClient` timeout limitation in Azure AI Foundry provider (SDK does not expose timeout kwargs); store `timeout_seconds` for async path
- **A-2**: Guard `response.usage` access in Foundry provider (return 0 when usage is None), matching the existing Azure OpenAI pattern
- **A-6/E-6**: Raise `ValueError` on unknown message roles in `_format_messages()` instead of silently dropping them
- **C-3**: Document non-cancellability of `asyncio.to_thread` in Foundry async docstring

## Test plan

- [x] All 41 existing LLM unit tests pass (40 pass, 3 skipped due to missing azure-ai-inference SDK, 1 new test added)
- [x] Ruff check and format pass on all LLM files
- [x] Pre-commit hooks pass on committed files
- [ ] Verify new validators reject bad input: invalid api_version formats, non-https endpoints, out-of-range timeout/retries
- [ ] Verify `from_env()` raises with specific env var name when variable is missing

Generated with [Claude Code](https://claude.com/claude-code)