### PR TITLE
refactor: Deduplicate sync/async in LLM providers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -152,9 +156,9 @@
         "filename": "tests/unit/test_llm_factory.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 52
       }
     ]
   },
-  "generated_at": "2026-02-27T00:58:02Z"
+  "generated_at": "2026-02-27T06:43:17Z"
 }

--- a/src/agent_haymaker/llm/providers/anthropic.py
+++ b/src/agent_haymaker/llm/providers/anthropic.py
@@ -4,7 +4,7 @@ Public API (the "studs"):
     AnthropicProvider: Anthropic Claude provider implementation
 """
 
-from anthropic import Anthropic, AsyncAnthropic, AuthenticationError, RateLimitError
+from anthropic import Anthropic, AuthenticationError, RateLimitError
 
 from agent_haymaker.llm.config import LLMConfig
 from agent_haymaker.llm.exceptions import (
@@ -28,11 +28,6 @@ class AnthropicProvider(BaseLLMProvider):
         api_key = config.api_key.get_secret_value() if config.api_key else None
 
         self._client = Anthropic(
-            api_key=api_key,
-            timeout=config.timeout_seconds,
-            max_retries=config.max_retries,
-        )
-        self._async_client = AsyncAnthropic(
             api_key=api_key,
             timeout=config.timeout_seconds,
             max_retries=config.max_retries,
@@ -91,36 +86,12 @@ class AnthropicProvider(BaseLLMProvider):
         max_tokens: int = 1024,
         temperature: float = 0.7,
     ) -> LLMResponse:
-        try:
-            formatted_messages = [{"role": msg.role, "content": msg.content} for msg in messages]
+        """Create a message asynchronously. Delegates to sync method via thread pool."""
+        import asyncio
 
-            kwargs = {
-                "model": self._model,
-                "max_tokens": max_tokens,
-                "temperature": temperature,
-                "messages": formatted_messages,
-            }
-            if system:
-                kwargs["system"] = system
-
-            response = await self._async_client.messages.create(**kwargs)
-
-            return LLMResponse(
-                content=response.content[0].text,
-                model=response.model,
-                usage={
-                    "input_tokens": response.usage.input_tokens,
-                    "output_tokens": response.usage.output_tokens,
-                },
-                stop_reason=response.stop_reason,
-            )
-
-        except AuthenticationError as e:
-            raise LLMAuthenticationError(f"Anthropic authentication failed: {e}") from e
-        except RateLimitError as e:
-            raise LLMRateLimitError(f"Anthropic rate limit exceeded: {e}") from e
-        except Exception as e:
-            raise LLMProviderError(f"Anthropic error: {e}") from e
+        return await asyncio.to_thread(
+            self.create_message, messages, system, max_tokens, temperature
+        )
 
 
 __all__ = ["AnthropicProvider"]

--- a/src/agent_haymaker/llm/providers/base.py
+++ b/src/agent_haymaker/llm/providers/base.py
@@ -37,7 +37,6 @@ class BaseLLMProvider(ABC):
         """
         ...
 
-    @abstractmethod
     async def create_message_async(
         self,
         messages: list[LLMMessage],
@@ -46,6 +45,9 @@ class BaseLLMProvider(ABC):
         temperature: float = 0.7,
     ) -> LLMResponse:
         """Create a message asynchronously.
+
+        Default delegates to create_message via asyncio.to_thread.
+        Override for native async implementations.
 
         Args:
             messages: List of conversation messages
@@ -56,7 +58,11 @@ class BaseLLMProvider(ABC):
         Returns:
             LLMResponse with generated content
         """
-        ...
+        import asyncio
+
+        return await asyncio.to_thread(
+            self.create_message, messages, system, max_tokens, temperature
+        )
 
 
 __all__ = ["BaseLLMProvider"]

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -35,8 +35,7 @@ class TestCreateLLMClient:
 
     @pytest.mark.skipif(not HAS_ANTHROPIC, reason="anthropic not installed")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
-    def test_creates_anthropic_provider(self, mock_async, mock_sync):
+    def test_creates_anthropic_provider(self, mock_sync):
         config = LLMConfig(provider="anthropic", api_key="sk-test")
         client = create_llm_client(config)
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
@@ -45,8 +44,7 @@ class TestCreateLLMClient:
 
     @pytest.mark.skipif(not HAS_OPENAI, reason="openai not installed")
     @patch("agent_haymaker.llm.providers.azure_openai.AzureOpenAI")
-    @patch("agent_haymaker.llm.providers.azure_openai.AsyncAzureOpenAI")
-    def test_creates_azure_openai_provider(self, mock_async, mock_sync):
+    def test_creates_azure_openai_provider(self, mock_sync):
         config = LLMConfig(
             provider="azure_openai",
             endpoint="https://test.openai.azure.com",

--- a/tests/unit/test_llm_providers.py
+++ b/tests/unit/test_llm_providers.py
@@ -14,47 +14,41 @@ from agent_haymaker.llm.types import LLMMessage, LLMResponse
 class TestAnthropicProvider:
     """Tests for AnthropicProvider initialization and interface."""
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_init_creates_clients(self, mock_sync, mock_async):
+    def test_init_creates_clients(self, mock_sync):
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
 
         config = LLMConfig(provider="anthropic", api_key="sk-test")
         AnthropicProvider(config)
 
         mock_sync.assert_called_once()
-        mock_async.assert_called_once()
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_default_model(self, mock_sync, mock_async):
+    def test_default_model(self, mock_sync):
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
 
         config = LLMConfig(provider="anthropic", api_key="sk-test")
         provider = AnthropicProvider(config)
         assert provider._model == "claude-sonnet-4-20250514"
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_custom_model(self, mock_sync, mock_async):
+    def test_custom_model(self, mock_sync):
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
 
         config = LLMConfig(provider="anthropic", api_key="sk-test", model="claude-opus-4-20250514")
         provider = AnthropicProvider(config)
         assert provider._model == "claude-opus-4-20250514"
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_is_base_provider(self, mock_sync, mock_async):
+    def test_is_base_provider(self, mock_sync):
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
 
         config = LLMConfig(provider="anthropic", api_key="sk-test")
         provider = AnthropicProvider(config)
         assert isinstance(provider, BaseLLMProvider)
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_has_create_message(self, mock_sync, mock_async):
+    def test_has_create_message(self, mock_sync):
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
 
         config = LLMConfig(provider="anthropic", api_key="sk-test")
@@ -62,9 +56,8 @@ class TestAnthropicProvider:
         assert hasattr(provider, "create_message")
         assert callable(provider.create_message)
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_has_create_message_async(self, mock_sync, mock_async):
+    def test_has_create_message_async(self, mock_sync):
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
 
         config = LLMConfig(provider="anthropic", api_key="sk-test")
@@ -72,9 +65,8 @@ class TestAnthropicProvider:
         assert hasattr(provider, "create_message_async")
         assert callable(provider.create_message_async)
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_create_message_returns_llm_response(self, mock_sync, mock_async):
+    def test_create_message_returns_llm_response(self, mock_sync):
         """Verify create_message correctly maps SDK response to LLMResponse."""
         from agent_haymaker.llm.providers.anthropic import AnthropicProvider
 
@@ -102,9 +94,8 @@ class TestAnthropicProvider:
         assert response.usage["output_tokens"] == 5
         assert response.stop_reason == "end_turn"
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_anthropic_auth_error_mapping(self, mock_sync, mock_async):
+    def test_anthropic_auth_error_mapping(self, mock_sync):
         """AuthenticationError from SDK maps to LLMAuthenticationError."""
         from anthropic import AuthenticationError
 
@@ -123,9 +114,8 @@ class TestAnthropicProvider:
         with pytest.raises(LLMAuthenticationError):
             provider.create_message(messages=[LLMMessage(role="user", content="Hello")])
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_anthropic_rate_limit_error_mapping(self, mock_sync, mock_async):
+    def test_anthropic_rate_limit_error_mapping(self, mock_sync):
         """RateLimitError from SDK maps to LLMRateLimitError."""
         from anthropic import RateLimitError
 
@@ -158,9 +148,8 @@ class TestAzureOpenAIProvider:
         with pytest.raises(ValidationError, match="deployment is required"):
             LLMConfig(provider="azure_openai", endpoint="https://test.openai.azure.com")
 
-    @patch("agent_haymaker.llm.providers.azure_openai.AsyncAzureOpenAI")
     @patch("agent_haymaker.llm.providers.azure_openai.AzureOpenAI")
-    def test_init_with_api_key(self, mock_sync, mock_async):
+    def test_init_with_api_key(self, mock_sync):
         from agent_haymaker.llm.providers.azure_openai import AzureOpenAIProvider
 
         config = LLMConfig(
@@ -171,12 +160,10 @@ class TestAzureOpenAIProvider:
         )
         provider = AzureOpenAIProvider(config)
         mock_sync.assert_called_once()
-        mock_async.assert_called_once()
         assert isinstance(provider, BaseLLMProvider)
 
-    @patch("agent_haymaker.llm.providers.azure_openai.AsyncAzureOpenAI")
     @patch("agent_haymaker.llm.providers.azure_openai.AzureOpenAI")
-    def test_has_both_message_methods(self, mock_sync, mock_async):
+    def test_has_both_message_methods(self, mock_sync):
         from agent_haymaker.llm.providers.azure_openai import AzureOpenAIProvider
 
         config = LLMConfig(
@@ -248,9 +235,8 @@ class TestAzureAIFoundryProvider:
 class TestProviderFactory:
     """Tests for the provider factory function."""
 
-    @patch("agent_haymaker.llm.providers.anthropic.AsyncAnthropic")
     @patch("agent_haymaker.llm.providers.anthropic.Anthropic")
-    def test_factory_creates_anthropic(self, mock_sync, mock_async):
+    def test_factory_creates_anthropic(self, mock_sync):
         from agent_haymaker.llm.factory import create_llm_client
 
         config = LLMConfig(provider="anthropic", api_key="sk-test")


### PR DESCRIPTION
## Summary
- Replace duplicated async implementations in `AnthropicProvider` and `AzureOpenAIProvider` with `asyncio.to_thread` delegation to the canonical sync `create_message` method, matching the pattern already used by `AzureAIFoundryProvider`
- Add a default `create_message_async` in `BaseLLMProvider` so subclasses get async support for free (can still override for native async)
- Remove `AsyncAnthropic` and `AsyncAzureOpenAI` client instantiation, reducing initialization overhead and eliminating ~85 lines of duplicated logic

## Test plan
- [x] All 110 existing tests pass (3 skipped for missing optional deps)
- [x] ruff check and ruff format pass
- [x] detect-secrets baseline updated
- [x] Pre-commit hooks all green
- [x] Verified no references to `AsyncAnthropic`, `AsyncAzureOpenAI`, or `_async_client` remain in provider source or tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)