### PR TITLE
feat: Platform Protocol, name enforcement, Click context

### DIFF
--- a/src/agent_haymaker/cli/main.py
+++ b/src/agent_haymaker/cli/main.py
@@ -20,17 +20,20 @@ import click
 
 from ..workloads import WorkloadRegistry
 
-# Global registry instance
-_registry: WorkloadRegistry | None = None
-
 
 def get_registry() -> WorkloadRegistry:
-    """Get or create the workload registry."""
-    global _registry
-    if _registry is None:
-        _registry = WorkloadRegistry()
-        _registry.discover_workloads()
-    return _registry
+    """Get the workload registry from Click context, or create one.
+
+    Uses Click context when running inside the CLI. Falls back to
+    creating a new registry for non-Click contexts (testing, programmatic use).
+    """
+    ctx = click.get_current_context(silent=True)
+    if ctx and ctx.obj and "registry" in ctx.obj:
+        return ctx.obj["registry"]
+    # Fallback for non-Click contexts
+    registry = WorkloadRegistry()
+    registry.discover_workloads()
+    return registry
 
 
 def run_async(coro: Any) -> Any:
@@ -40,7 +43,8 @@ def run_async(coro: Any) -> Any:
 
 @click.group()
 @click.version_option(version=pkg_version("agent-haymaker"), prog_name="agent-haymaker")
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """Agent Haymaker - Universal workload orchestration platform.
 
     Deploy and manage workloads that generate telemetry for Azure tenants
@@ -60,7 +64,10 @@ def cli() -> None:
         haymaker workload list
         haymaker workload install <git-url>
     """
-    pass
+    ctx.ensure_object(dict)
+    registry = WorkloadRegistry()
+    registry.discover_workloads()
+    ctx.obj["registry"] = registry
 
 
 # Import command modules to register commands with the cli group.

--- a/src/agent_haymaker/workloads/__init__.py
+++ b/src/agent_haymaker/workloads/__init__.py
@@ -6,10 +6,12 @@ workload implementations must inherit from.
 
 from .base import WorkloadBase
 from .models import DeploymentConfig, DeploymentState, DeploymentStatus, WorkloadManifest
+from .platform import Platform
 from .registry import WorkloadRegistry
 
 __all__ = [
     "WorkloadBase",
+    "Platform",
     "DeploymentState",
     "DeploymentStatus",
     "DeploymentConfig",

--- a/src/agent_haymaker/workloads/platform.py
+++ b/src/agent_haymaker/workloads/platform.py
@@ -1,0 +1,46 @@
+"""Platform protocol - defines the contract workloads expect from the platform.
+
+Public API (the "studs"):
+    Platform: Protocol defining platform services available to workloads
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .models import DeploymentState
+
+
+@runtime_checkable
+class Platform(Protocol):
+    """Protocol defining platform services available to workloads.
+
+    Workloads receive a Platform instance at construction time and use it
+    for state persistence, credential management, and logging.
+
+    Implementations must provide all methods defined here.
+    """
+
+    async def save_deployment_state(self, state: DeploymentState) -> None:
+        """Persist deployment state."""
+        ...
+
+    async def load_deployment_state(self, deployment_id: str) -> DeploymentState | None:
+        """Load deployment state by ID."""
+        ...
+
+    async def list_deployments(self, workload_name: str) -> list[DeploymentState]:
+        """List all deployments for a workload."""
+        ...
+
+    async def get_credential(self, name: str) -> str | None:
+        """Get a credential by name (e.g., from Key Vault)."""
+        ...
+
+    def log(self, message: str, level: str = "INFO", workload: str = "") -> None:
+        """Log a message."""
+        ...
+
+
+__all__ = ["Platform"]

--- a/src/agent_haymaker/workloads/registry.py
+++ b/src/agent_haymaker/workloads/registry.py
@@ -7,17 +7,19 @@ The registry is responsible for:
 4. Providing workload instances to the CLI/API
 """
 
+from __future__ import annotations
+
 import logging
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
 
 import yaml
 
 from .base import WorkloadBase
 from .models import WorkloadManifest
+from .platform import Platform
 
 _logger = logging.getLogger(__name__)
 
@@ -34,7 +36,7 @@ class WorkloadRegistry:
     # Entry point group for workload discovery
     ENTRY_POINT_GROUP = "agent_haymaker.workloads"
 
-    def __init__(self, platform: Any = None) -> None:
+    def __init__(self, platform: Platform | None = None) -> None:
         """Initialize the registry.
 
         Args:


### PR DESCRIPTION
## Summary

Three structural improvements from the multi-agent quality review.

### Platform Protocol
- New `workloads/platform.py` defines the 5-method contract (`save_deployment_state`, `load_deployment_state`, `list_deployments`, `get_credential`, `log`)
- `WorkloadBase` and `WorkloadRegistry` now use `Platform | None` instead of `Any`
- Exported from public API for workload authors

### Name Enforcement
- `__init_subclass__` on `WorkloadBase` prevents concrete subclasses from inheriting default `name = "base"`
- Raises `TypeError` at class definition time (not runtime)

### Click Context Registry
- Replaced module-level `_registry` global with Click context (`ctx.obj["registry"]`)
- Eliminates test state pollution and enables future daemon/server use
- Fallback for non-Click contexts preserved

## Test plan
- [x] 117 tests pass, 3 skipped
- [x] Pre-commit all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)