### PR TITLE
feat: FilePlatform, deployment cache, config-file, data-driven env, async consolidation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -127,6 +123,29 @@
     }
   ],
   "results": {
+    "src/agent_haymaker/llm/config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agent_haymaker/llm/config.py",
+        "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agent_haymaker/llm/config.py",
+        "hashed_secret": "04827ce753ca41ba673b446b1c94b47a905a59b6",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agent_haymaker/llm/config.py",
+        "hashed_secret": "b04ef9d60974d4d1ad698afafbf52c4e079da6e6",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
     "tests/unit/test_llm_config.py": [
       {
         "type": "Secret Keyword",
@@ -160,5 +179,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-27T06:43:17Z"
+  "generated_at": "2026-02-27T10:59:03Z"
 }

--- a/src/agent_haymaker/cli/lifecycle.py
+++ b/src/agent_haymaker/cli/lifecycle.py
@@ -14,13 +14,18 @@ from ..workloads.models import DeploymentState
 from ..workloads.registry import WorkloadRegistry
 from .main import cli, get_registry, run_async
 
+# Module-level cache: deployment_id -> workload_name
+# Provides O(1) lookup on repeated access to the same deployment.
+_deployment_index: dict[str, str] = {}
 
-def _find_deployment(
+
+async def _find_deployment_async(
     registry: WorkloadRegistry, deployment_id: str
 ) -> tuple[WorkloadBase, DeploymentState]:
     """Find the workload and state for a deployment ID.
 
-    Searches all registered workloads for the given deployment.
+    Checks the module-level _deployment_index cache first for O(1) lookup,
+    falling back to scanning all registered workloads on cache miss.
 
     Args:
         registry: Workload registry to search
@@ -32,11 +37,26 @@ def _find_deployment(
     Raises:
         click.ClickException: If deployment not found in any workload
     """
+    # Check cache first for O(1) lookup
+    if deployment_id in _deployment_index:
+        cached_name = _deployment_index[deployment_id]
+        workload = registry.get_workload(cached_name)
+        if workload:
+            try:
+                state = await workload.get_status(deployment_id)
+                return workload, state
+            except DeploymentNotFoundError:
+                # Stale cache entry - remove and fall through to scan
+                del _deployment_index[deployment_id]
+
+    # Cache miss: scan all workloads
     for name in registry.list_workloads():
         workload = registry.get_workload(name)
         if workload:
             try:
-                state = run_async(workload.get_status(deployment_id))
+                state = await workload.get_status(deployment_id)
+                # Cache the result for future lookups
+                _deployment_index[deployment_id] = name
                 return workload, state
             except DeploymentNotFoundError:
                 continue
@@ -61,20 +81,24 @@ def status(deployment_id: str, output_format: str) -> None:
         haymaker status dep-abc123
         haymaker status dep-abc123 --format json
     """
-    registry = get_registry()
-    _workload, state = _find_deployment(registry, deployment_id)
 
-    if output_format == "json":
-        click.echo(state.model_dump_json(indent=2))
-    else:
-        click.echo(f"Deployment: {state.deployment_id}")
-        click.echo(f"  Workload: {state.workload_name}")
-        click.echo(f"  Status:   {state.status}")
-        click.echo(f"  Phase:    {state.phase}")
-        if state.started_at:
-            click.echo(f"  Started:  {state.started_at}")
-        if state.error:
-            click.echo(f"  Error:    {state.error}")
+    async def _run() -> None:
+        registry = get_registry()
+        _workload, state = await _find_deployment_async(registry, deployment_id)
+
+        if output_format == "json":
+            click.echo(state.model_dump_json(indent=2))
+        else:
+            click.echo(f"Deployment: {state.deployment_id}")
+            click.echo(f"  Workload: {state.workload_name}")
+            click.echo(f"  Status:   {state.status}")
+            click.echo(f"  Phase:    {state.phase}")
+            if state.started_at:
+                click.echo(f"  Started:  {state.started_at}")
+            if state.error:
+                click.echo(f"  Error:    {state.error}")
+
+    run_async(_run())
 
 
 # =============================================================================
@@ -100,40 +124,46 @@ def list_deployments(
         haymaker list --workload m365-knowledge-worker
         haymaker list --status running
     """
-    registry = get_registry()
-    all_deployments = []
 
-    workloads_to_check = [workload] if workload else registry.list_workloads()
+    async def _run() -> None:
+        registry = get_registry()
+        all_deployments: list[DeploymentState] = []
 
-    for name in workloads_to_check:
-        wl = registry.get_workload(name)
-        if wl:
-            try:
-                deployments = run_async(wl.list_deployments())
-                all_deployments.extend(deployments)
-            except DeploymentNotFoundError:
-                continue
+        workloads_to_check = [workload] if workload else registry.list_workloads()
 
-    # Filter by status
-    if status:
-        all_deployments = [d for d in all_deployments if d.status == status]
+        for name in workloads_to_check:
+            wl = registry.get_workload(name)
+            if wl:
+                try:
+                    deployments = await wl.list_deployments()
+                    all_deployments.extend(deployments)
+                except DeploymentNotFoundError:
+                    continue
 
-    # Limit
-    all_deployments = all_deployments[:limit]
+        # Filter by status
+        if status:
+            all_deployments = [d for d in all_deployments if d.status == status]
 
-    if not all_deployments:
-        click.echo("No deployments found.")
-        return
+        # Limit
+        all_deployments = all_deployments[:limit]
 
-    if output_format == "json":
-        import json
+        if not all_deployments:
+            click.echo("No deployments found.")
+            return
 
-        click.echo(json.dumps([d.model_dump() for d in all_deployments], indent=2, default=str))
-    else:
-        click.echo(f"{'ID':<20} {'Workload':<25} {'Status':<12} {'Phase':<15}")
-        click.echo("-" * 75)
-        for d in all_deployments:
-            click.echo(f"{d.deployment_id:<20} {d.workload_name:<25} {d.status:<12} {d.phase:<15}")
+        if output_format == "json":
+            import json
+
+            click.echo(json.dumps([d.model_dump() for d in all_deployments], indent=2, default=str))
+        else:
+            click.echo(f"{'ID':<20} {'Workload':<25} {'Status':<12} {'Phase':<15}")
+            click.echo("-" * 75)
+            for d in all_deployments:
+                click.echo(
+                    f"{d.deployment_id:<20} {d.workload_name:<25} {d.status:<12} {d.phase:<15}"
+                )
+
+    run_async(_run())
 
 
 # =============================================================================
@@ -154,18 +184,18 @@ def logs(deployment_id: str, follow: bool, lines: int) -> None:
         haymaker logs dep-abc123 --follow
         haymaker logs dep-abc123 -n 50
     """
-    registry = get_registry()
-    workload, _state = _find_deployment(registry, deployment_id)
 
-    async def stream_logs() -> None:
+    async def _run() -> None:
+        registry = get_registry()
+        wl, _state = await _find_deployment_async(registry, deployment_id)
         try:
-            async for line in workload.get_logs(deployment_id, follow=follow, lines=lines):
+            async for line in wl.get_logs(deployment_id, follow=follow, lines=lines):
                 click.echo(line.rstrip())
         except Exception as e:
             click.echo(f"Error streaming logs: {e}", err=True)
             sys.exit(1)
 
-    run_async(stream_logs())
+    run_async(_run())
 
 
 # =============================================================================
@@ -184,23 +214,27 @@ def stop(deployment_id: str, yes: bool) -> None:
         haymaker stop dep-abc123
         haymaker stop dep-abc123 --yes
     """
-    registry = get_registry()
-    workload, state = _find_deployment(registry, deployment_id)
 
-    if state.status != DeploymentStatus.RUNNING:
-        click.echo(f"Deployment is not running (status: {state.status})")
-        sys.exit(1)
+    async def _run() -> None:
+        registry = get_registry()
+        wl, state = await _find_deployment_async(registry, deployment_id)
 
-    if not yes and not click.confirm(f"Stop deployment {deployment_id}?"):
-        click.echo("Aborted.")
-        sys.exit(0)
+        if state.status != DeploymentStatus.RUNNING:
+            click.echo(f"Deployment is not running (status: {state.status})")
+            sys.exit(1)
 
-    success = run_async(workload.stop(deployment_id))
-    if success:
-        click.echo(f"Deployment {deployment_id} stopped.")
-    else:
-        click.echo("Failed to stop deployment.")
-        sys.exit(1)
+        if not yes and not click.confirm(f"Stop deployment {deployment_id}?"):
+            click.echo("Aborted.")
+            sys.exit(0)
+
+        success = await wl.stop(deployment_id)
+        if success:
+            click.echo(f"Deployment {deployment_id} stopped.")
+        else:
+            click.echo("Failed to stop deployment.")
+            sys.exit(1)
+
+    run_async(_run())
 
 
 # =============================================================================
@@ -217,19 +251,23 @@ def start(deployment_id: str) -> None:
     Examples:
         haymaker start dep-abc123
     """
-    registry = get_registry()
-    workload, state = _find_deployment(registry, deployment_id)
 
-    if state.status == DeploymentStatus.RUNNING:
-        click.echo("Deployment is already running.")
-        return
+    async def _run() -> None:
+        registry = get_registry()
+        wl, state = await _find_deployment_async(registry, deployment_id)
 
-    success = run_async(workload.start(deployment_id))
-    if success:
-        click.echo(f"Deployment {deployment_id} started.")
-    else:
-        click.echo("Failed to start deployment.")
-        sys.exit(1)
+        if state.status == DeploymentStatus.RUNNING:
+            click.echo("Deployment is already running.")
+            return
+
+        success = await wl.start(deployment_id)
+        if success:
+            click.echo(f"Deployment {deployment_id} started.")
+        else:
+            click.echo("Failed to start deployment.")
+            sys.exit(1)
+
+    run_async(_run())
 
 
 # =============================================================================
@@ -252,26 +290,30 @@ def cleanup(deployment_id: str, yes: bool, dry_run: bool) -> None:
         haymaker cleanup dep-abc123
         haymaker cleanup dep-abc123 --dry-run
     """
-    registry = get_registry()
-    workload, state = _find_deployment(registry, deployment_id)
 
-    if dry_run:
-        click.echo(f"Would clean up deployment: {deployment_id}")
-        click.echo(f"  Workload: {state.workload_name}")
-        click.echo(f"  Status: {state.status}")
-        click.echo("(Dry run - no changes made)")
-        return
+    async def _run() -> None:
+        registry = get_registry()
+        wl, state = await _find_deployment_async(registry, deployment_id)
 
-    if not yes:
-        click.echo(f"This will delete all resources for deployment: {deployment_id}")
-        if not click.confirm("Are you sure?"):
-            click.echo("Aborted.")
-            sys.exit(0)
+        if dry_run:
+            click.echo(f"Would clean up deployment: {deployment_id}")
+            click.echo(f"  Workload: {state.workload_name}")
+            click.echo(f"  Status: {state.status}")
+            click.echo("(Dry run - no changes made)")
+            return
 
-    report = run_async(workload.cleanup(deployment_id))
-    click.echo(f"Cleanup complete for {deployment_id}")
-    click.echo(f"  Resources deleted: {report.resources_deleted}")
-    if report.errors:
-        click.echo("  Errors:")
-        for err in report.errors:
-            click.echo(f"    - {err}")
+        if not yes:
+            click.echo(f"This will delete all resources for deployment: {deployment_id}")
+            if not click.confirm("Are you sure?"):
+                click.echo("Aborted.")
+                sys.exit(0)
+
+        report = await wl.cleanup(deployment_id)
+        click.echo(f"Cleanup complete for {deployment_id}")
+        click.echo(f"  Resources deleted: {report.resources_deleted}")
+        if report.errors:
+            click.echo("  Errors:")
+            for err in report.errors:
+                click.echo(f"    - {err}")
+
+    run_async(_run())

--- a/src/agent_haymaker/cli/main.py
+++ b/src/agent_haymaker/cli/main.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import click
 
-from ..workloads import WorkloadRegistry
+from ..workloads import FilePlatform, WorkloadRegistry
 
 
 def get_registry() -> WorkloadRegistry:
@@ -31,7 +31,8 @@ def get_registry() -> WorkloadRegistry:
     if ctx and ctx.obj and "registry" in ctx.obj:
         return ctx.obj["registry"]
     # Fallback for non-Click contexts
-    registry = WorkloadRegistry()
+    platform = FilePlatform()
+    registry = WorkloadRegistry(platform=platform)
     registry.discover_workloads()
     return registry
 
@@ -65,7 +66,8 @@ def cli(ctx: click.Context) -> None:
         haymaker workload install <git-url>
     """
     ctx.ensure_object(dict)
-    registry = WorkloadRegistry()
+    platform = FilePlatform()
+    registry = WorkloadRegistry(platform=platform)
     registry.discover_workloads()
     ctx.obj["registry"] = registry
 

--- a/src/agent_haymaker/workloads/__init__.py
+++ b/src/agent_haymaker/workloads/__init__.py
@@ -5,12 +5,14 @@ workload implementations must inherit from.
 """
 
 from .base import WorkloadBase
+from .file_platform import FilePlatform
 from .models import DeploymentConfig, DeploymentState, DeploymentStatus, WorkloadManifest
 from .platform import Platform
 from .registry import WorkloadRegistry
 
 __all__ = [
     "WorkloadBase",
+    "FilePlatform",
     "Platform",
     "DeploymentState",
     "DeploymentStatus",

--- a/src/agent_haymaker/workloads/file_platform.py
+++ b/src/agent_haymaker/workloads/file_platform.py
@@ -1,0 +1,178 @@
+"""File-based Platform implementation.
+
+Stores deployment state as JSON files on the local filesystem.
+Reads credentials from environment variables. Logs via stdlib logging.
+
+Public API (the "studs"):
+    FilePlatform: Concrete Platform implementation using local files
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+from .models import DeploymentState
+
+_logger = logging.getLogger(__name__)
+
+# Pattern for valid deployment IDs: alphanumeric, hyphens, underscores, dots
+_SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+
+def _sanitize_deployment_id(deployment_id: str) -> str:
+    """Sanitize a deployment ID to prevent path traversal.
+
+    Args:
+        deployment_id: Raw deployment ID
+
+    Returns:
+        Sanitized deployment ID safe for use as a filename
+
+    Raises:
+        ValueError: If deployment_id is empty or contains path traversal
+    """
+    if not deployment_id:
+        raise ValueError("deployment_id must not be empty")
+
+    # Reject any path separator characters
+    if "/" in deployment_id or "\\" in deployment_id:
+        raise ValueError(f"deployment_id contains path separators: {deployment_id!r}")
+
+    # Reject path traversal patterns
+    if ".." in deployment_id:
+        raise ValueError(f"deployment_id contains path traversal: {deployment_id!r}")
+
+    # Validate against safe pattern
+    if not _SAFE_ID_PATTERN.match(deployment_id):
+        raise ValueError(
+            f"deployment_id contains invalid characters: {deployment_id!r}. "
+            "Only alphanumeric, hyphens, underscores, and dots are allowed."
+        )
+
+    return deployment_id
+
+
+class FilePlatform:
+    """File-based Platform implementation.
+
+    Stores deployment state as JSON in ~/.haymaker/state/{deployment_id}.json.
+    Reads credentials from environment variables.
+    Logs via stdlib logging.
+
+    This implementation satisfies the Platform protocol without requiring
+    any cloud services, making it suitable for local development and testing.
+    """
+
+    def __init__(self, state_dir: Path | None = None) -> None:
+        """Initialize FilePlatform.
+
+        Args:
+            state_dir: Directory for state files. Defaults to ~/.haymaker/state/
+        """
+        if state_dir is None:
+            state_dir = Path.home() / ".haymaker" / "state"
+        self._state_dir = state_dir
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+
+    def _state_path(self, deployment_id: str) -> Path:
+        """Get the file path for a deployment's state.
+
+        Args:
+            deployment_id: Deployment identifier (will be sanitized)
+
+        Returns:
+            Path to the state JSON file
+        """
+        safe_id = _sanitize_deployment_id(deployment_id)
+        return self._state_dir / f"{safe_id}.json"
+
+    async def save_deployment_state(self, state: DeploymentState) -> None:
+        """Persist deployment state to a JSON file.
+
+        Args:
+            state: Deployment state to save
+        """
+        path = self._state_path(state.deployment_id)
+        data = state.model_dump_json(indent=2)
+        path.write_text(data)
+        _logger.debug("Saved deployment state to %s", path)
+
+    async def load_deployment_state(self, deployment_id: str) -> DeploymentState | None:
+        """Load deployment state from a JSON file.
+
+        Args:
+            deployment_id: ID of the deployment to load
+
+        Returns:
+            DeploymentState if found, None otherwise
+        """
+        path = self._state_path(deployment_id)
+        if not path.exists():
+            _logger.debug("No state file found at %s", path)
+            return None
+
+        raw = path.read_text()
+        return DeploymentState.model_validate_json(raw)
+
+    async def list_deployments(self, workload_name: str) -> list[DeploymentState]:
+        """List all deployments for a given workload.
+
+        Scans all state files and filters by workload_name.
+
+        Args:
+            workload_name: Name of the workload to filter by
+
+        Returns:
+            List of matching deployment states
+        """
+        results: list[DeploymentState] = []
+        if not self._state_dir.exists():
+            return results
+
+        for state_file in self._state_dir.glob("*.json"):
+            try:
+                raw = state_file.read_text()
+                state = DeploymentState.model_validate_json(raw)
+                if state.workload_name == workload_name:
+                    results.append(state)
+            except Exception:
+                _logger.warning("Failed to read state file %s", state_file, exc_info=True)
+
+        return results
+
+    async def get_credential(self, name: str) -> str | None:
+        """Get a credential from environment variables.
+
+        Looks up the credential by name as an environment variable.
+        The name is converted to uppercase with hyphens replaced by underscores.
+
+        Args:
+            name: Credential name (e.g., "azure-tenant-id" -> AZURE_TENANT_ID)
+
+        Returns:
+            Credential value or None if not found
+        """
+        env_key = name.upper().replace("-", "_")
+        value = os.environ.get(env_key)
+        if value is None:
+            _logger.debug("Credential %r (env: %s) not found", name, env_key)
+        return value
+
+    def log(self, message: str, level: str = "INFO", workload: str = "") -> None:
+        """Log a message via stdlib logging.
+
+        Args:
+            message: Log message
+            level: Log level name (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+            workload: Workload name for logger context
+        """
+        logger_name = f"haymaker.workload.{workload}" if workload else "haymaker"
+        logger = logging.getLogger(logger_name)
+        log_level = getattr(logging, level.upper(), logging.INFO)
+        logger.log(log_level, message)
+
+
+__all__ = ["FilePlatform"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Shared test fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_deployment_index_cache():
+    """Clear the lifecycle deployment index cache between tests."""
+    from agent_haymaker.cli import lifecycle
+
+    lifecycle._deployment_index.clear()
+    yield
+    lifecycle._deployment_index.clear()

--- a/tests/unit/test_file_platform.py
+++ b/tests/unit/test_file_platform.py
@@ -1,0 +1,231 @@
+"""Tests for FilePlatform - file-based state persistence."""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agent_haymaker.workloads.file_platform import FilePlatform, _sanitize_deployment_id
+from agent_haymaker.workloads.models import DeploymentState, DeploymentStatus
+
+
+def _run(coro):
+    """Helper to run async coroutines in tests."""
+    return asyncio.run(coro)
+
+
+class TestSanitizeDeploymentId:
+    """Tests for deployment ID sanitization."""
+
+    def test_valid_simple_id(self):
+        assert _sanitize_deployment_id("dep-001") == "dep-001"
+
+    def test_valid_id_with_dots(self):
+        assert _sanitize_deployment_id("dep.001.test") == "dep.001.test"
+
+    def test_valid_id_with_underscores(self):
+        assert _sanitize_deployment_id("dep_001_test") == "dep_001_test"
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _sanitize_deployment_id("")
+
+    def test_rejects_path_traversal_dotdot(self):
+        # ../etc/passwd contains slashes so it hits the path separator check first
+        with pytest.raises(ValueError, match="path separators"):
+            _sanitize_deployment_id("../etc/passwd")
+
+    def test_rejects_dotdot_without_slash(self):
+        with pytest.raises(ValueError, match="path traversal"):
+            _sanitize_deployment_id("..evil")
+
+    def test_rejects_forward_slash(self):
+        with pytest.raises(ValueError, match="path separators"):
+            _sanitize_deployment_id("foo/bar")
+
+    def test_rejects_backslash(self):
+        with pytest.raises(ValueError, match="path separators"):
+            _sanitize_deployment_id("foo\\bar")
+
+    def test_rejects_leading_dot(self):
+        with pytest.raises(ValueError, match="invalid characters"):
+            _sanitize_deployment_id(".hidden")
+
+    def test_rejects_spaces(self):
+        with pytest.raises(ValueError, match="invalid characters"):
+            _sanitize_deployment_id("dep 001")
+
+
+class TestFilePlatformSaveLoad:
+    """Tests for save and load operations."""
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        state = DeploymentState(
+            deployment_id="dep-001",
+            workload_name="test-workload",
+            status=DeploymentStatus.RUNNING,
+            phase="executing",
+        )
+        _run(platform.save_deployment_state(state))
+        loaded = _run(platform.load_deployment_state("dep-001"))
+        assert loaded is not None
+        assert loaded.deployment_id == "dep-001"
+        assert loaded.workload_name == "test-workload"
+        assert loaded.status == DeploymentStatus.RUNNING
+        assert loaded.phase == "executing"
+
+    def test_load_nonexistent_returns_none(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        result = _run(platform.load_deployment_state("nonexistent"))
+        assert result is None
+
+    def test_save_creates_json_file(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        state = DeploymentState(
+            deployment_id="dep-002",
+            workload_name="test",
+            status=DeploymentStatus.PENDING,
+        )
+        _run(platform.save_deployment_state(state))
+        assert (tmp_path / "dep-002.json").exists()
+
+    def test_save_overwrites_existing(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        state1 = DeploymentState(
+            deployment_id="dep-003",
+            workload_name="test",
+            status=DeploymentStatus.PENDING,
+        )
+        state2 = DeploymentState(
+            deployment_id="dep-003",
+            workload_name="test",
+            status=DeploymentStatus.RUNNING,
+        )
+        _run(platform.save_deployment_state(state1))
+        _run(platform.save_deployment_state(state2))
+        loaded = _run(platform.load_deployment_state("dep-003"))
+        assert loaded is not None
+        assert loaded.status == DeploymentStatus.RUNNING
+
+
+class TestFilePlatformListDeployments:
+    """Tests for listing deployments."""
+
+    def test_list_empty_directory(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        result = _run(platform.list_deployments("test-workload"))
+        assert result == []
+
+    def test_list_filters_by_workload_name(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        states = [
+            DeploymentState(
+                deployment_id="dep-a",
+                workload_name="workload-a",
+                status=DeploymentStatus.RUNNING,
+            ),
+            DeploymentState(
+                deployment_id="dep-b",
+                workload_name="workload-b",
+                status=DeploymentStatus.RUNNING,
+            ),
+            DeploymentState(
+                deployment_id="dep-c",
+                workload_name="workload-a",
+                status=DeploymentStatus.STOPPED,
+            ),
+        ]
+        for s in states:
+            _run(platform.save_deployment_state(s))
+
+        result = _run(platform.list_deployments("workload-a"))
+        assert len(result) == 2
+        ids = {d.deployment_id for d in result}
+        assert ids == {"dep-a", "dep-c"}
+
+    def test_list_ignores_corrupt_files(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        # Write a valid state
+        state = DeploymentState(
+            deployment_id="dep-good",
+            workload_name="test",
+            status=DeploymentStatus.RUNNING,
+        )
+        _run(platform.save_deployment_state(state))
+        # Write a corrupt file
+        (tmp_path / "corrupt.json").write_text("not valid json{{{")
+
+        result = _run(platform.list_deployments("test"))
+        assert len(result) == 1
+        assert result[0].deployment_id == "dep-good"
+
+
+class TestFilePlatformCredentials:
+    """Tests for credential retrieval from environment."""
+
+    def test_get_credential_from_env(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        with patch.dict(os.environ, {"AZURE_TENANT_ID": "test-tenant-123"}):
+            result = _run(platform.get_credential("azure-tenant-id"))
+            assert result == "test-tenant-123"
+
+    def test_get_credential_missing_returns_none(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        # Ensure the env var is not set
+        env = dict(os.environ)
+        env.pop("NONEXISTENT_CREDENTIAL", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = _run(platform.get_credential("nonexistent-credential"))
+            assert result is None
+
+    def test_credential_name_conversion(self, tmp_path):
+        platform = FilePlatform(state_dir=tmp_path)
+        with patch.dict(os.environ, {"MY_SECRET_KEY": "secret-value"}):  # pragma: allowlist secret
+            result = _run(platform.get_credential("my-secret-key"))
+            assert result == "secret-value"
+
+
+class TestFilePlatformLogging:
+    """Tests for the log method."""
+
+    def test_log_default_level(self, tmp_path, caplog):
+        platform = FilePlatform(state_dir=tmp_path)
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="haymaker.workload.test-wl"):
+            platform.log("Hello world", workload="test-wl")
+        assert "Hello world" in caplog.text
+
+    def test_log_with_level(self, tmp_path, caplog):
+        platform = FilePlatform(state_dir=tmp_path)
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="haymaker"):
+            platform.log("A warning", level="WARNING")
+        assert "A warning" in caplog.text
+
+    def test_log_without_workload(self, tmp_path, caplog):
+        platform = FilePlatform(state_dir=tmp_path)
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="haymaker"):
+            platform.log("Generic message")
+        assert "Generic message" in caplog.text
+
+
+class TestFilePlatformInit:
+    """Tests for initialization."""
+
+    def test_default_state_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        platform = FilePlatform()
+        assert platform._state_dir == tmp_path / ".haymaker" / "state"
+        assert platform._state_dir.exists()
+
+    def test_custom_state_dir(self, tmp_path):
+        custom = tmp_path / "custom" / "state"
+        platform = FilePlatform(state_dir=custom)
+        assert platform._state_dir == custom
+        assert custom.exists()


### PR DESCRIPTION
## Summary

- **FilePlatform**: New concrete `Platform` implementation that persists deployment state as JSON in `~/.haymaker/state/`, reads credentials from environment variables, logs via stdlib logging, and sanitizes deployment IDs to prevent path traversal. Wired into CLI as the default platform.
- **Deployment index cache**: Module-level `_deployment_index` dict in `lifecycle.py` provides O(1) cached lookup of `deployment_id -> workload_name`, falling back to full workload scan on cache miss.
- **Config file support**: New `--config-file` option on `deploy` command reads a YAML file and merges with CLI `--config` flags (CLI takes precedence). Supports `workload_name` and `duration_hours` as top-level fields.
- **Data-driven `from_env()`**: Replaced branchy if/elif in `LLMConfig.from_env()` with `_PROVIDER_ENV_MAP` and `_PROVIDER_REQUIRED_FIELDS` dicts, looping over the map to construct config. All existing tests pass unchanged.
- **Async consolidation**: Made `_find_deployment` async (`_find_deployment_async`) and wrapped each lifecycle command's full logic in a single `run_async()` call, creating one event loop per CLI invocation instead of N.

## Test plan

- [x] New `tests/unit/test_file_platform.py` with 24 tests covering save/load roundtrip, list filtering, credential env lookup, logging, path traversal sanitization, and init
- [x] 4 new config-file tests in `tests/unit/test_cli.py` covering YAML loading, CLI precedence, missing file, and workload_name extraction
- [x] All existing `test_llm_config.py` tests pass unchanged against data-driven `from_env()`
- [x] `tests/conftest.py` added to clear deployment index cache between tests
- [x] 146 passed, 3 skipped (Azure AI Foundry optional dependency tests)
- [x] `ruff check --fix` and `ruff format` clean
- [x] `detect-secrets scan` baseline updated
- [x] All pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)